### PR TITLE
Add flask-based lemma analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# greek_language
+# Greek Language Web Application
+
+This project provides a minimal web application for analyzing Greek words. The first feature extracts the lemma and basic morphological information for a given word using spaCy's Greek model.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Application
+
+```bash
+python app.py
+```
+
+Navigate to `http://localhost:5000` and enter a Greek word to see its lemma and morphological analysis.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, request, render_template
+import spacy
+
+nlp = spacy.load("el_core_news_sm")
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    result = None
+    if request.method == 'POST':
+        word = request.form.get('word', '').strip()
+        if word:
+            doc = nlp(word)
+            result = []
+            for token in doc:
+                result.append({
+                    'text': token.text,
+                    'lemma': token.lemma_,
+                    'pos': token.pos_,
+                    'morph': token.morph.to_dict()
+                })
+    return render_template('index.html', result=result)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==3.0.2
+spacy==3.7.2
+el-core-news-sm==3.7.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Greek Lemma Analyzer</title>
+</head>
+<body>
+    <h1>Greek Lemma and Morphology</h1>
+    <form method="post">
+        <input type="text" name="word" placeholder="Enter Greek word" required>
+        <button type="submit">Analyze</button>
+    </form>
+    {% if result %}
+    <h2>Analysis</h2>
+    <table border="1" cellpadding="5">
+        <tr>
+            <th>Token</th>
+            <th>Lemma</th>
+            <th>POS</th>
+            <th>Morphology</th>
+        </tr>
+        {% for token in result %}
+        <tr>
+            <td>{{ token.text }}</td>
+            <td>{{ token.lemma }}</td>
+            <td>{{ token.pos }}</td>
+            <td>
+                {% for key, val in token.morph.items() %}
+                    {{ key }}={{ val }}<br>
+                {% endfor %}
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create Flask web app for lemma and morphology analysis
- add simple HTML template
- document setup and usage
- specify requirements for Flask and spaCy Greek model

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt --no-cache-dir`
- `python app.py` *(started and stopped after confirming launch)*

------
https://chatgpt.com/codex/tasks/task_e_6850fa7940d4832e9a9de605a0a5107d